### PR TITLE
Fix build with classy-prelude 1.4

### DIFF
--- a/ezmon.cabal
+++ b/ezmon.cabal
@@ -10,7 +10,7 @@ executable ezmon
   main-is:              Main.hs
   hs-source-dirs:       src
   build-depends:        base
-                      , classy-prelude
+                      , classy-prelude >= 1.4
                       , directory
                       , extra
                       , optparse-applicative

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -37,7 +37,6 @@ If no configuration file exists for a particular layout, the default command is
 -}
 
 import           ClassyPrelude
-import           Control.Exception.Safe  (catchIO)
 import           Control.Monad.Extra     (andM, ifM)
 import           Options.Applicative
 import           System.Directory

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-11.5


### PR DESCRIPTION
I realize you are going on holiday soon, but `stack init` chooses a resolver which uses a newer version of classy-prelude.  This newer version exports `catchIO`, causing the build to fail.  This PR fixes the issue.